### PR TITLE
Escaping ampersand character in URLs on Windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Escaping ampersand character in URLs on Windows platform
+
 ## 2.0.0
 
 - Stable null-safety!

--- a/lib/src/open_url_base.dart
+++ b/lib/src/open_url_base.dart
@@ -11,7 +11,7 @@ Future<ProcessResult> openUrl(String url) {
   if (Platform.isWindows) {
     /// This is needed because ampersand has to be escaped with carret on Windows shell,
     /// otherwise opened URL will be trimmed by first ampersand
-    url = url.replaceAllMapped(RegExp("([^^])&"),(m) => "${m[1]}^&");
+    url = url.replaceAllMapped(RegExp('([^^])&'), (m) => '${m[1]}^&');
   }
   return Process.run(_command, [url], runInShell: true);
 }

--- a/lib/src/open_url_base.dart
+++ b/lib/src/open_url_base.dart
@@ -8,6 +8,11 @@ import 'dart:io';
 /// A process is spawned to run that utility, with the [ProcessResult]
 /// being returned.
 Future<ProcessResult> openUrl(String url) {
+  if (Platform.isWindows) {
+    /// This is needed because ampersand has to be escaped with carret on Windows shell,
+    /// otherwise opened URL will be trimmed by first ampersand
+    url = url.replaceAllMapped(RegExp("([^^])&"),(m) => "${m[1]}^&");
+  }
   return Process.run(_command, [url], runInShell: true);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_url
 description: Open a URL on the user's default application. Helpful on DartVM, on Flutter use url_launcher instead.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/renatoathaydes/open_url
 
 environment:


### PR DESCRIPTION
On version 2.0.0 when you open URL: `https://domain.com?param1=1&param2=2` only `https://domain.com?param1=1` will open. This is fixed by this PR by escaping ampersand with caret symbol